### PR TITLE
PatchOperationFindMod's mod name fix

### DIFF
--- a/1.4/Patches/AddCaravanPatch.xml
+++ b/1.4/Patches/AddCaravanPatch.xml
@@ -20,7 +20,7 @@
     </Operation>
     <Operation Class="PatchOperationFindMod">
         <mods>
-            <li>DankPyon.Medieval.Overhaul</li>
+            <li>Medieval Overhaul</li>
         </mods>
         <match Class="PatchOperationSequence">
             <operations>
@@ -54,7 +54,7 @@
     </Operation>
     <Operation Class="PatchOperationFindMod">
         <mods>
-            <li>OskarPotocki.VFE.Classical</li>
+            <li>Vanilla Factions Expanded - Classical</li>
         </mods>
         <match Class="PatchOperationSequence">
             <operations>


### PR DESCRIPTION
I think the previous one was more of a package id instead of an actual mod name, so the patch operation probably won't work since it's looking for a non-existing mod